### PR TITLE
Update README.md for singleton_test

### DIFF
--- a/feature/interface/singleton/otg_tests/singleton_test/README.md
+++ b/feature/interface/singleton/otg_tests/singleton_test/README.md
@@ -15,7 +15,7 @@ a new testbed configuration with the desired port types.
     the octets of IPv4.
   * Ensure: ARP discovers static MAC address specified when port is
         configured with static MAC.
-### Subtest 1 - singleton interface verification:
+### RT-5.1.1 - singleton interface verification:
 * Validate that port speed is reported correctly and that port telemetry
     matches expected negotiated speeds for forced, auto-negotiation, and
     auto-negotiation while overriding port speed and duplex.
@@ -31,7 +31,7 @@ a new testbed configuration with the desired port types.
 
 [^1]: The MTU specified above refers to the L3 MTU, which is the payload portion
     of an Ethernet frame.
-### Subtest 2 - link flaps:
+### RT-5.1.2 - link flaps:
 * Bring down the physical layer of ATE port-1, and bring it back up.
     Repeat this a few times (minimum 2)
   * Verify that the interface goes down by checking the physical state on DUT/ATE.
@@ -40,6 +40,10 @@ a new testbed configuration with the desired port types.
             captured in the OC path.
   * Verify that the traffic flow from ATE port-1 to ATE port-2 is
             now working after the interface is back up.
+### RT-5.1.3 - Verify accurate reporting of `hardware-port` on all interfaces:
+* The test should start with taking an inventory of all available interfaces on the DUT irrespective of their admin-status or breakout state.
+* The test should check for `/interfaces/interface/state/hardware-port` reporting on all available physical interfaces in the DUT irrespective of their admin-status or breakout state
+* Compare results in both the bullets above and confirm that the DUT is not missing reporting of `state/hardware-port` on any physical interface irrespective of their breakout state. If missed, the test is a failure. 
 
 ## Config Parameter Coverage
 


### PR DESCRIPTION
Subtest added to cover for scenarios whereby a DUT can stop reporting `/state/hardware-port` details for an interface after an OS change. Given that a device can report this leaf for an interface irrespective of its admin-status, this sub-test should be able to cover for different breakout configurations that exits on the DUT.