### PR TITLE
RT-5.7 Fix

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/metadata.textproto
@@ -28,7 +28,6 @@ platform_exceptions: {
     wecmp_auto_unsupported: true
     isis_loopback_required: true
     weighted_ecmp_fixed_packet_verification: true
-    interface_ref_interface_id_format: true
   }
 }
 

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -148,10 +148,22 @@ test: {
   exec: " "
 }
 test: {
+  id: "Authz"
+  description: "General Authz (1-4) tests"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnsi/authz/tests/authz/README.md"
+  exec: "feature/gnsi/authz/tests/authz/metadata.textproto"
+}
+test: {
   id: "Authz-4"
   description: "reboot persistent"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/security/gnsi/authz/tests/README.md"
   exec: " "
+}
+test: {
+  id: "BMP-1.1"
+  description: "BMP Session Establishment and Telemetry Test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/bmp/otg_tests/bmp_base_session_test/README.md"
+  exec: "feature/bgp/bmp/otg_tests/bmp_base_session_test/metadata.textproto"
 }
 test: {
   id: "BMP-2.1"
@@ -220,6 +232,18 @@ test: {
 test: {
   id: "Certz-5"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/ssecurity/gnsi/certz/trust_bundle_rotation/README.md"
+}
+test: {
+  id: "CFM-1.1"
+  description: "CFM over ETHoCWoMPLSoGRE"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/cfm/otg_tests/cfm_base/README.md"
+  exec: "feature/cfm/otg_tests/cfm_base/metadata.textproto"
+}
+test: {
+  id: "CNTR-3"
+  description: "Container Supervisor Failover"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/failover/tests/supervisor_failover/README.md"
+  exec: "feature/container/failover/tests/supervisor_failover/metadata.textproto"
 }
 test: {
   id: "CPT-1.1"
@@ -365,6 +389,18 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/qos/ingress_policer/otg_tests/ingress_police_two_rate_three_color_with_classifier/README.md"
 }
 test: {
+  id: "enrollz-1"
+  description: "enrollz test for TPM 2.0 HMAC-based Enrollment flow"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/security/attestz/tests/enrollz_tpm20_hmac/README.md"
+  exec: "feature/security/attestz/tests/enrollz_tpm20_hmac/metadata.textproto"
+}
+test: {
+  id: "enrollz-2"
+  description: "enrollz test for TPM 1.2 Enrollment flow"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/security/attestz/tests/enrollz_tpm12/README.md"
+  exec: "feature/security/attestz/tests/enrollz_tpm12/metadata.textproto"
+}
+test: {
   id: "FP-1.1"
   description: "Power admin DOWN/UP Test"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/tests/power_admin_down_up_test/README.md"
@@ -399,6 +435,24 @@ test: {
   exec: " "
 }
 test: {
+  id: "IPSEC-1.1"
+  description: "IPSec with MACSec over aggregated links."
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/ipsec/otg_tests/ipsec_base/README.md"
+  exec: "feature/ipsec/otg_tests/ipsec_base/metadata.textproto"
+}
+test: {
+  id: "IPSEC-1.2"
+  description: "IPSec Scaling with MACSec over aggregated links."
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/ipsec/otg_tests/ipsec_scale/README.md"
+  exec: "feature/ipsec/otg_tests/ipsec_scale/metadata.textproto"
+}
+test: {
+  id: "IPSEC-1.3"
+  description: "IPSec Packet-Order with MACSec over aggregated links."
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/ipsec/otg_tests/ipsec_packetorder/README.md"
+  exec: "feature/ipsec/otg_tests/ipsec_packetorder/metadata.textproto"
+}
+test: {
   id: "MGT-1"
   description: "Management HA test"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/management/README.md"
@@ -415,6 +469,12 @@ test: {
   description: "MPLS Traffic Class Marking"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/otg_tests/mpls_tc/README.md"
   exec: " "
+}
+test: {
+  id: "MPLS-2.2"
+  description: "MPLS forwarding via static LSP to BGP next-hop."
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/otg_tests/static_bgp_nexthop/README.md"
+  exec: "feature/mpls/otg_tests/static_bgp_nexthop/metadata.textproto"
 }
 test: {
   id: "MTU-1.3"
@@ -481,6 +541,12 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/p4rt/otg_tests/google_discovery_protocol_packetout_test/README.md"
 }
 test: {
+  id: "P4RT-3.21"
+  description: "Google Discovery Protocol: PacketOut with LAG"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/p4rt/otg_tests/google_discovery_protocol_packetout_lag_test/README.md"
+  exec: "feature/p4rt/otg_tests/google_discovery_protocol_packetout_lag_test/metadata.textproto"
+}
+test: {
   id: "P4RT-5.1"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/p4rt/otg_tests/traceroute_packetin_test/README.md"
 }
@@ -515,6 +581,12 @@ test: {
   description: "Policy-based traffic GRE Encapsulation to IPv4 GRE tunnel"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/encapsulation/otg_tests/encap_gre_ipv4/README.md"
   exec: " "
+}
+test: {
+  id: "PF-1.3"
+  description: "Policy-based IPv4 GRE Decapsulation"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/encapsulation/otg_tests/decap_gre_ipv4/README.md"
+  exec: "feature/policy_forwarding/encapsulation/otg_tests/decap_gre_ipv4/metadata.textproto"
 }
 test: {
   id: "PF-1.4"
@@ -635,6 +707,12 @@ test: {
   exec: " "
 }
 test: {
+  id: "PF-1.24"
+  description: "Add and remove interface bound to PBF"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/otg_tests/add_remove_policy_bound_interface_test/README.md"
+  exec: "feature/policy_forwarding/otg_tests/add_remove_policy_bound_interface_test/metadata.textproto"
+}
+test: {
   id: "PF-2.3"
   description: "Multiple VRFs and GUE DECAP in Default VRF"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/vrf_selection/otg_tests/multiple_vrfs_and_gue_decap/README.md"
@@ -657,6 +735,18 @@ test: {
   description: "DHCP Relay functionality"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/helper_address/otg_tests/relay_agent_test/README.md" 
   exec: " "
+}
+test: {
+  id: "PLT-1.3"
+  description: "OnChange Subscription Test for Breakout Interfaces"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/tests/breakout_subscription_test/README.md"
+  exec: "feature/platform/tests/breakout_subscription_test/metadata.textproto"
+}
+test: {
+  id: "RT-1.1"
+  description: "Base BGP Session Parameters"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/otg_tests/base_bgp_session_parameters/README.md"
+  exec: "feature/bgp/otg_tests/base_bgp_session_parameters/metadata.textproto"
 }
 test: {
   id: "RT-1.2"
@@ -774,6 +864,18 @@ test: {
   exec: " "
 }
 test: {
+  id: "RT-2.18"
+  description: "Scale for IS-IS with multiple adjacencies"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/isis/otg_tests/isis_scale_multi_adjacency_test/README.md"
+  exec: "feature/isis/otg_tests/isis_scale_multi_adjacency_test/metadata.textproto"
+}
+test: {
+  id: "RT-10.2"
+  description: "Non-default Route Generation based on 192.168.2.2/32 Presence in ISIS"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/isis/policy/otg_tests/generate_route/README.md"
+  exec: "feature/isis/policy/otg_tests/generate_route/metadata.textproto"
+}
+test: {
   id: "RT-1.22"
   description: ": BGP Link Bandwidth Community for recursive routes"
   readme: ""
@@ -808,6 +910,12 @@ test: {
   description: "Static route to BGP redistribution"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/README.md"
   exec: " "
+}
+test: {
+  id: "SR-1.2"
+  description: "Egress Node Forwarding for MPLS traffic with Explicit Null label"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/sr/otg_tests/srte_egress_node_forwarding/README.md"
+  exec: "feature/mpls/sr/otg_tests/srte_egress_node_forwarding/metadata.textproto"
 }
 test: {
   id: "RT-1.28"
@@ -1292,6 +1400,18 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/generate_route/otg_tests/generate_default_route/README.md"
 }
 test: {
+  id: "Replay-1.0"
+  description: "Record/replay presession test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/replay/tests/presession_test/README.md"
+  exec: "feature/replay/tests/presession_test/metadata.textproto"
+}
+test: {
+  id: "Replay-1.1"
+  description: "Record/replay diff command trees test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/replay/tests/diff_command_trees/README.md"
+  exec: "feature/replay/tests/diff_command_trees/metadata.textproto"
+}
+test: {
   id: "Replay-1.2"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/replay/tests/p4rt_replay/README.md"
 }
@@ -1516,6 +1636,54 @@ test: {
   description: "gRIBI Get RPC"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/ate_tests/get_rpc_test/README.md"
   exec: " "
+}
+test: {
+  id: "TE-2.2"
+  description: "gRIBI IPv4 Entry With Aggregate Ports"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/ipv4_entry_with_aggregate_ports_test/README.md"
+  exec: "feature/gribi/otg_tests/ipv4_entry_with_aggregate_ports_test/metadata.textproto"
+}
+test: {
+  id: "TE-8.1"
+  description: "DUT Daemon Failure"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/dut_daemon_failure/README.md"
+  exec: "feature/gribi/otg_tests/dut_daemon_failure/metadata.textproto"
+}
+test: {
+  id: "TE-11.1"
+  description: "Backup NHG: Single NH"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/backup_nhg_single_nh_test/README.md"
+  exec: "feature/gribi/otg_tests/backup_nhg_single_nh_test/metadata.textproto"
+}
+test: {
+  id: "TE-11.21"
+  description: "Backup NHG: Multiple NH with PBF"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/backup_nhg_multiple_nh_pbf_test/README.md"
+  exec: "feature/gribi/otg_tests/backup_nhg_multiple_nh_pbf_test/metadata.textproto"
+}
+test: {
+  id: "TE-11.3"
+  description: "Backup NHG: Actions"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/backup_nhg_action/README.md"
+  exec: "feature/gribi/otg_tests/backup_nhg_action/metadata.textproto"
+}
+test: {
+  id: "TE-11.31"
+  description: "Backup NHG: Actions with PBF"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/backup_nhg_action_pbf/README.md"
+  exec: "feature/gribi/otg_tests/backup_nhg_action_pbf/metadata.textproto"
+}
+test: {
+  id: "TE-18.4"
+  description: "ECMP hashing on outer and inner packets with MPLSoUDP encapsulation"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/mpls_in_udp/otg_tests/mpls_over_udp_tunnel_hashing_test/README.md"
+  exec: "feature/gribi/mpls_in_udp/otg_tests/mpls_over_udp_tunnel_hashing_test/metadata.textproto"
+}
+test: {
+  id: "TestID-16.4"
+  description: "gRIBI to BGP Route Redistribution for IPv4"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/gribi_to_bgp_redistribution/README.md"
+  exec: "feature/gribi/otg_tests/gribi_to_bgp_redistribution/metadata.textproto"
 }
 test: {
   id: "TE-6.1"
@@ -1903,6 +2071,18 @@ test: {
   exec: " "
 }
 test: {
+  id: "gNMI-1.2"
+  description: "Benchmarking: Full Configuration Replace"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/tests/full_configuration_replace_test/README.md"
+  exec: "feature/gnmi/tests/full_configuration_replace_test/metadata.textproto"
+}
+test: {
+  id: "gNMI-1.3"
+  description: "Benchmarking: Drained Configuration Convergence Time"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/otg_tests/drained_configuration_convergence_time/README.md"
+  exec: "feature/gnmi/otg_tests/drained_configuration_convergence_time/metadata.textproto"
+}
+test: {
   id: "gNMI-1.10"
   description: "Telemetry: Basic Check"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/otg_tests/telemetry_basic_check_test/README.md"
@@ -1949,6 +2129,12 @@ test: {
   description: "Set Requests"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/gnmi/set/tests/gnmi_set_test/metadata.textproto"
   exec: " "
+}
+test: {
+  id: "gNMI-1.24"
+  description: "gNMI Leaf-List Update Test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/tests/leaflist_update_test/README.md"
+  exec: "feature/gnmi/tests/leaflist_update_test/metadata.textproto"
 }
 test: {
   id: "gNMI-1.16"
@@ -2074,6 +2260,12 @@ test: {
   exec: " "
 }
 test: {
+  id: "gNOI-7.1"
+  description: "BootConfig"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnoi/secure_boot/tests/bootconfig/README.md"
+  exec: "feature/gnoi/secure_boot/tests/bootconfig/metadata.textproto"
+}
+test: {
   id: "gNOI-5.1"
   description: "Ping Test"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnoi/system/tests/ping_test/README.md"
@@ -2180,6 +2372,54 @@ test: {
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/control_plane_traffic/otg_tests/ingress_acl/control_plane_traffic_ingress_acl_test.go"
 }
 test: {
+  id: "SYS-3.1"
+  description: "AAA and TACACS+ Configuration Verification Test Suite"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/aaa/tests/tacacs/README.md"
+  exec: "feature/system/aaa/tests/tacacs/metadata.textproto"
+}
+test: {
+  id: "SYS-4.1"
+  description: "System Mount Points State Verification"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/mount_points/tests/system_mount_points_state/README.md"
+  exec: "feature/system/mount_points/tests/system_mount_points_state/metadata.textproto"
+}
+test: {
+  id: "bootz"
+  description: "General bootz bootstrap tests"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/secure_boot/tests/bootz/README.md"
+  exec: "feature/system/secure_boot/tests/bootz/metadata.textproto"
+}
+test: {
+  id: "System-1.1"
+  description: "System banner test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/system_base_test/tests/system_banner_test/README.md"
+  exec: "feature/system/system_base_test/tests/system_banner_test/metadata.textproto"
+}
+test: {
+  id: "System-1.2"
+  description: "System g protocol test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/system_base_test/tests/system_g_protocol_test/README.md"
+  exec: "feature/system/system_base_test/tests/system_g_protocol_test/metadata.textproto"
+}
+test: {
+  id: "System-1.3"
+  description: "System hostname test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/system_base_test/tests/hostname_test/README.md"
+  exec: "feature/system/system_base_test/tests/hostname_test/metadata.textproto"
+}
+test: {
+  id: "System-1.4"
+  description: "System time test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/system_base_test/tests/system_time_test/README.md"
+  exec: "feature/system/system_base_test/tests/system_time_test/metadata.textproto"
+}
+test: {
+  id: "System-1.5"
+  description: "System software-version test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/system/system_base_test/tests/system_software_version/README.md"
+  exec: "feature/system/system_base_test/tests/system_software_version/metadata.textproto"
+}
+test: {
   id: "TRANSCEIVER-1.2"
   description: "Telemetry: 400ZR_PLUS Chromatic Dispersion(CD) telemetry values streaming"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/zrp_cd_test/README.md"
@@ -2208,6 +2448,12 @@ test: {
   description: "Telemetry: 400ZR_PLUS Optics inventory info streaming"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/zrp_inventory_test/README.md"
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/zrp_inventory_test/zrp_inventory_test.go"
+}
+test: {
+  id: "TRANSCEIVER-7.1"
+  description: "Telemetry: 400ZR Optics inventory info streaming"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/zr_inventory_test/README.md"
+  exec: "feature/platform/transceiver/tests/zr_inventory_test/metadata.textproto"
 }
 test: {
   id: "TRANSCEIVER-9.2"
@@ -2294,6 +2540,18 @@ test: {
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/otg_tests/telemetry_interface_carrier_transitions_test/carrier_transitions_test.go"
 }
 test: {
+  id: "gNMI-1.27"
+  description: "gNMI Sample Mode Test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/subscribe/tests/gnmi_sample_mode_test/README.md"
+  exec: "feature/gnmi/subscribe/tests/gnmi_sample_mode_test/metadata.textproto"
+}
+test: {
+  id: "GNMI-2"
+  description: "gnmi_subscriptionlist_test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/subscribe/tests/gnmi_subscriptionlist_test/README.md"
+  exec: "feature/gnmi/subscribe/tests/gnmi_subscriptionlist_test/metadata.textproto"
+}
+test: {
   id: "TE-13.1"
   description: "gRIBI route ADD during Failover"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/route_addition_during_failover_test/README.md"
@@ -2310,34 +2568,4 @@ test: {
   description: "Transit forwarding to Node-SID via ISIS"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/sr/otg_tests/isis_node_sid_forward/README.md"
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go"
-}
-test: {
-  id: "MPLS-2.2"
-  description: "MPLS forwarding via static LSP to BGP next-hop."
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/otg_tests/static_bgp_nexthop/README.md"
-  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/otg_tests/static_bgp_nexthop/static_bgp_nexthop_test.go"
-}
-test: {
-  id: "PF-1.3"
-  description: "Policy-based IPv4 GRE Decapsulation"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/encapsulation/otg_tests/decap_gre_ipv4/README.md"
-  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/encapsulation/otg_tests/decap_gre_ipv4/decap_gre_ipv4_test.go"
-}
-test: {
-  id: "BMP-1.1"
-  description: "BMP Session Establishment and Telemetry Test"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/bmp/otg_tests/bmp_base_session_test/README.md"
-  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/bmp/otg_tests/bmp_base_session_test/bmp_base_session_test.go"
-}
-test: {
-  id: "RT-10.2"
-  description: "Non-default Route Generation based on 192.168.2.2/32 Presence in ISIS"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/isis/policy/otg_tests/generate_route/README.md"
-  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/isis/policy/otg_tests/generate_route/generate_route_test.go"
-}
-test: {
-  id: "SR-1.2"
-  description: "Egress Node Forwarding for MPLS traffic with Explicit Null label"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/sr/otg_tests/srte_egress_node_forwarding/README.md"
-  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/sr/otg_tests/srte_egress_node_forwarding/egress_node_forwading_test.go"
 }


### PR DESCRIPTION
RT-5.7 AGGREGATE ALL NOT VIABLE TEST - CODE CHANGES EXPLANATION

**CHANGE #1: VRF ASSIGNMENT FIX FOR CISCO LAG INTERFACES**

Location: aggregate_all_not_forwarding_viable_test.go, lines 529-537

Problem:
--------
The test was calling fptest.AssignToNetworkInstance() for all interfaces 
including LAG (Bundle-Ether) interfaces. On Cisco devices, LAG interfaces 
cannot be directly assigned to a VRF/Network Instance.

Error Message:
"'RSI' detected the 'warning' condition 'The specified interface type does not 
support VRFs'"

Code Change:
------------
BEFORE:
    fptest.AssignToNetworkInstance(t, dut, p.Name(), 
        deviations.DefaultNetworkInstance(dut), 0)

AFTER:
    // Assign the interface to the default network instance if not CISCO
    // Cisco LAG interfaces do not support VRF assignment
    if dut.Vendor() != ondatra.CISCO {
        fptest.AssignToNetworkInstance(t, dut, p.Name(), 
            deviations.DefaultNetworkInstance(dut), 0)
    }

Explanation:
------------
Cisco IOS-XR handles LAG interfaces differently from other vendors. Bundle-Ether
interfaces are implicitly part of the default network instance and cannot be 
explicitly assigned to a VRF. The fix adds a vendor check to skip this 
assignment for Cisco devices only.

**CHANGE #2: LOOPBACK INTERFACE CONFIGURATION FOR ISIS**

Location: aggregate_all_not_forwarding_viable_test.go, lines 561-564, 590-612

Problem:
--------
Cisco requires a loopback interface for ISIS to function properly. The test
was not configuring Loopback0 when the ISISLoopbackRequired deviation is true.

Code Added:
-----------
1. Conditional loopback configuration call:

    // Configure Loopback0 for Cisco where ISIS requires a loopback interface
    if deviations.ISISLoopbackRequired(dut) {
        configureLoopback(t, dut)
        aggIDs = append(aggIDs, "Loopback0")
    }

2. New configureLoopback function:

    func configureLoopback(t *testing.T, dut *ondatra.DUTDevice) {
        t.Helper()
        d := &oc.Root{}
        loopbackIntf := d.GetOrCreateInterface("Loopback0")
        loopbackIntf.Name = ygot.String("Loopback0")
        loopbackIntf.Description = ygot.String("Loopback for ISIS")
        loopbackIntf.Type = oc.IETFInterfaces_InterfaceType_softwareLoopback
        if deviations.InterfaceEnabled(dut) {
            loopbackIntf.Enabled = ygot.Bool(true)
        }
        s := loopbackIntf.GetOrCreateSubinterface(0)
        s4 := s.GetOrCreateIpv4()
        if deviations.InterfaceEnabled(dut) {
            s4.Enabled = ygot.Bool(true)
        }
        s4.GetOrCreateAddress(dutLoopback.IPv4).PrefixLength = ygot.Uint8(dutLoopback.IPv4Len)
        s6 := s.GetOrCreateIpv6()
        if deviations.InterfaceEnabled(dut) {
            s6.Enabled = ygot.Bool(true)
        }
        s6.GetOrCreateAddress(dutLoopback.IPv6).PrefixLength = ygot.Uint8(dutLoopback.IPv6Len)
        gnmi.Update(t, dut, gnmi.OC().Interface("Loopback0").Config(), loopbackIntf)
    }

Explanation:
------------
Cisco IOS-XR ISIS implementation requires a loopback interface to be configured
and included in ISIS for proper route advertisement. The Loopback0 interface:
- Uses IP 192.0.2.21/32 and 2001:db8::21/128
- Is added to the aggIDs list so it gets configured in ISIS
- Serves as the router-ID source for ISIS

**CHANGE #3: ISIS LOOPBACK INTERFACE HANDLING**

Location: aggregate_all_not_forwarding_viable_test.go, lines 801-840

Problem:
--------
The configureDUTISIS function was treating all interfaces the same:
1. Adding ".0" suffix to ALL interfaces when InterfaceRefInterfaceIDFormat is true
2. Setting CircuitType to POINT_TO_POINT for ALL interfaces
3. Not setting loopback interfaces as passive

This caused:
- Invalid interface name "Loopback0.0" (Cisco doesn't use this format)
- Loopback interfaces trying to form adjacencies (should be passive)

Code Change:
------------
BEFORE:
    for _, aggID := range aggIDs {
        isisIntf := isis.GetOrCreateInterface(aggID)
        if deviations.InterfaceRefInterfaceIDFormat(dut) {
            isisIntf = isis.GetOrCreateInterface(aggID + ".0")
        }
        // ... same treatment for all interfaces
        isisIntf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT

AFTER:
    for _, aggID := range aggIDs {
        isLoopback := strings.HasPrefix(strings.ToLower(aggID), "loopback")
        intfID := aggID
        // Only add .0 suffix for non-loopback interfaces
        // Loopback interfaces on Cisco do not use subinterface notation
        if deviations.InterfaceRefInterfaceIDFormat(dut) && !isLoopback {
            intfID = aggID + ".0"
        }
        isisIntf := isis.GetOrCreateInterface(intfID)
        // ...
        isisIntf.Enabled = ygot.Bool(true)
        // Loopback interfaces should be passive (they don't form ISIS adjacencies)
        if isLoopback {
            isisIntf.SetPassive(true)
        } else {
            isisIntf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT
        }

Explanation:
------------
1. Loopback Detection: strings.HasPrefix(strings.ToLower(aggID), "loopback")
   - Detects if the interface is a loopback interface
   
2. Skip ".0" suffix for loopback:
   - Cisco Loopback interfaces don't use subinterface notation
   - "Loopback0" is valid, "Loopback0.0" is NOT valid
   
3. Set Passive for loopback:
   - Loopback interfaces don't need to form ISIS adjacencies
   - They just advertise their routes into ISIS
   - SetPassive(true) tells ISIS to advertise the loopback subnet but not
     send/receive ISIS hello packets on this interface

4. CircuitType only for non-loopback:
   - POINT_TO_POINT circuit type is only for actual network interfaces
   - Loopback interfaces are internal and don't have a circuit type

**CHANGE** #4: ISIS ADJACENCY LOOKUP PATH FIX

Location: aggregate_all_not_forwarding_viable_test.go, lines 243-246, 396-399, 
          1253-1261

Problem:
--------
The awaitAdjacency function and direct gnmi.LookupAll calls were using the base
interface name (e.g., "Bundle-Ether2") to query ISIS adjacency state. However,
when InterfaceRefInterfaceIDFormat deviation is true, ISIS interface would be
configured as "Bundle-Ether2.0", causing lookups to fail.

Code Change:
------------
1. Modified awaitAdjacency function:

    func awaitAdjacency(t *testing.T, dut *ondatra.DUTDevice, intfName string, 
                        state []oc.E_Isis_IsisInterfaceAdjState) bool {
        isisIntfID := intfName
        // When InterfaceRefInterfaceIDFormat is true, ISIS interface ID has .0 suffix
        if deviations.InterfaceRefInterfaceIDFormat(dut) && 
           !strings.HasPrefix(strings.ToLower(intfName), "loopback") {
            isisIntfID = intfName + ".0"
        }
        isisPath := ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
            Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis()
        intf := isisPath.Interface(isisIntfID)
        // ...
    }

2. Fixed direct gnmi.LookupAll calls:

    if ok := awaitAdjacency(...); !ok {
        isisIntfID := aggIDs[1]
        if deviations.InterfaceRefInterfaceIDFormat(dut) {
            isisIntfID = aggIDs[1] + ".0"
        }
        if presence := gnmi.LookupAll(t, dut, ocpath.Root()...
            .Isis().Interface(isisIntfID).LevelAny()...); len(presence) > 0 {
            // ...
        }
    }

Explanation:
------------
The ISIS state query path must match the configured ISIS interface name. When
InterfaceRefInterfaceIDFormat deviation is enabled, the ISIS interface is
configured with ".0" suffix, so queries must also use the same suffix.

**CHANGE** #5: METADATA DEVIATION FIX (CRITICAL)

Location: metadata.textproto, Cisco platform_exceptions section

Problem:
--------
The test had `interface_ref_interface_id_format: true` deviation set for Cisco,
but comparing with WORKING Cisco ISIS tests revealed they don't use this deviation:

| Test                         | Uses interface_ref_interface_id_format |
|------------------------------|----------------------------------------|
| weighted_ecmp_test (WORKS)   | NO                                     |
| isis_drain_test (WORKS)      | NO                                     |
| aggregate_all_not_viable     | YES <-- PROBLEM                        |

This deviation was causing:
1. ISIS interface names to use ".0" suffix (Bundle-Ether2.0)
2. Mismatch between configured interface and ISIS adjacency lookup
3. ISIS adjacency never forming properly

Code Change:
------------
BEFORE:
    platform_exceptions: {
      platform: {
        vendor: CISCO
      }
      deviations: {
        interface_ref_config_unsupported:true
        wecmp_auto_unsupported: true
        isis_loopback_required: true
        weighted_ecmp_fixed_packet_verification: true
        interface_ref_interface_id_format: true   <-- REMOVED
      }
    }

AFTER:
    platform_exceptions: {
      platform: {
        vendor: CISCO
      }
      deviations: {
        interface_ref_config_unsupported:true
        wecmp_auto_unsupported: true
        isis_loopback_required: true
        weighted_ecmp_fixed_packet_verification: true
      }
    }

Explanation:
------------
The interface_ref_interface_id_format deviation is used for certain interfaces
that require subinterface notation in their configuration. However, for Cisco
LAG interfaces in ISIS, this is not needed. Working Cisco ISIS tests use only:
- interface_ref_config_unsupported: true (skip interface-ref in ISIS config)
- isis_loopback_required: true (configure Loopback0 for ISIS)

Removing this unnecessary deviation ensures ISIS interfaces are configured
with the correct names that match the actual interface names on the device.


**FILES MODIFIED**

1. aggregate_all_not_forwarding_viable_test.go
   - Added vendor check for VRF assignment (Change #1)
   - Added configureLoopback function (Change #2)
   - Modified configureDUTISIS for loopback handling (Change #3)
   - Modified awaitAdjacency and gnmi.LookupAll calls (Change #4)

2. metadata.textproto
   - Removed interface_ref_interface_id_format deviation (Change #5)
