### PR TITLE
P200 | Health-1.1 fix

### DIFF
--- a/feature/system/health/tests/system_generic_health_check/system_generic_health_check_test.go
+++ b/feature/system/health/tests/system_generic_health_check/system_generic_health_check_test.go
@@ -333,7 +333,7 @@ func TestLineCardsNoHighCPUSpike(t *testing.T) {
 			}
 		}
 		if len(baseLCs) == 0 {
-			t.Errorf("ERROR: No Cisco linecard CPU base components found")
+			t.Skip("Skip the test as no linecard CPU base components were found.")
 		}
 		// Skip non-removable linecards
 		var removable []string


### PR DESCRIPTION
Skip the test on "No Cisco line card CPU base components found," because the P200 Mustang is a fixed box without line cards.